### PR TITLE
PM-10367: Bump some gems june 13 part 3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 PATH
   remote: .
   specs:
-    feature_flagging (0.0.2)
-      launchdarkly-server-sdk (~> 6.2)
+    feature_flagging (0.0.4)
+      launchdarkly-server-sdk (~> 6.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
@@ -22,17 +22,17 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       llhttp-ffi (~> 0.4.0)
-    http-cookie (1.0.4)
+    http-cookie (1.0.5)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    json (2.6.1)
-    launchdarkly-server-sdk (6.2.5)
+    json (2.6.2)
+    launchdarkly-server-sdk (6.3.3)
       concurrent-ruby (~> 1.1)
       http (>= 4.4.0, < 6.0.0)
       json (~> 2.3)
-      ld-eventsource (= 2.1.1)
+      ld-eventsource (= 2.2.1)
       semantic (~> 1.6)
-    ld-eventsource (2.1.1)
+    ld-eventsource (2.2.1)
       concurrent-ruby (~> 1.0)
       http (>= 4.4.1, < 6.0.0)
     listen (3.7.0)
@@ -41,7 +41,7 @@ GEM
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
@@ -62,7 +62,7 @@ GEM
     semantic (1.6.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8)
+    unf_ext (0.0.8.2)
 
 PLATFORMS
   ruby

--- a/feature_flagging.gemspec
+++ b/feature_flagging.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "launchdarkly-server-sdk", "~> 6.2"
+  spec.add_dependency "launchdarkly-server-sdk", "~> 6.3"
 
   spec.add_development_dependency "listen", "~> 3.7.0"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/feature_flagging/version.rb
+++ b/lib/feature_flagging/version.rb
@@ -1,3 +1,3 @@
 module FeatureFlagging
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Updating dependencies, especially `launchdarkly-server-sdk`, so we are able to update it in ShopFloor